### PR TITLE
Add a loading screen to the web page

### DIFF
--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,0 +1,3 @@
+assets/
+bevy_game.js
+bevy_game_bg.wasm

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="./loading_screen.mjs"></script>
+
+    <script type="module">
+      // Load the game asynchronously
+      import("./bevy_game.js").then((game) => {
+        game.default();
+      });
+    </script>
+
+    <style>
+      body {
+        margin: 0px;
+        height: 100vh;
+        width: 100vw;
+        overflow: hidden;
+
+        background-color: white;
+        color: #023e8a;
+      }
+
+      #loading-screen {
+        width: 100%;
+        height: 100%;
+
+        display: flex;
+        flex-flow: column;
+        justify-content: center;
+        align-items: center;
+
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      #loading-indicator {
+        font-size: 4em;
+      }
+    </style>
+  </head>
+
+  <body id="body">
+    <div id="loading-screen">
+      <div id="loading-indicator">
+        Loading<span id="loading-dots">...</span>
+      </div>
+      <div>Made with Bevy</div>
+    </div>
+  </body>
+</html>

--- a/wasm/loading_screen.mjs
+++ b/wasm/loading_screen.mjs
@@ -1,0 +1,58 @@
+const MAX_DOT_COUNT = 3;
+
+window.addEventListener("DOMContentLoaded", () => {
+  const body = document.getElementById("body");
+  const loadingScreen = document.getElementById("loading-screen");
+  const dotElement = document.getElementById("loading-dots");
+
+  if (body === null || loadingScreen === null || dotElement === null) {
+    console.error("Can't find loading screen elements!");
+    return;
+  };
+
+  let dotCount = 0;
+
+  function animateLoadingDots() {
+    dotElement.innerText = ".".repeat(dotCount).padEnd(3, "\u{00A0}");
+
+    dotCount += 1;
+
+    if (dotCount > MAX_DOT_COUNT) {
+      dotCount = 0;
+    }
+  }
+
+  function removeLoadingScreen() {
+    clearInterval(loadingInterval);
+    loadingScreen.remove();
+  }
+
+  // Wait for the `canvas` element to be created
+  // This tells us that the game has been fully loaded
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const addedNode of mutation.addedNodes) {
+        console.debug("addedNode", addedNode, addedNode.ELEMENT_NODE);
+        if (addedNode.ELEMENT_NODE === 1) {
+          /** @type HTMLElement */
+          const element = addedNode;
+
+          console.debug(element.tagName);
+
+          if (element.tagName === "CANVAS") {
+            // The game has been loaded!
+            // We don't need the loading screen anymore
+            removeLoadingScreen();
+            observer.disconnect();
+          }
+        }
+      }
+    }
+  });
+
+  observer.observe(body, {
+    childList: true,
+  });
+
+  const loadingInterval = setInterval(animateLoadingDots, 1000);
+});


### PR DESCRIPTION
This PR adds a loading screen to the web page.
Because the WASM binary is quite big, it can take a long time for the game to load. In this time, the user just sees a black/white screen and might be confused why nothing is happening.

This PR adds a (very simple) loading screen to indicate that something is happening. It could be expanded arbitrarily in the future, if needed.

It currently looks like this:
![Loading... Made with Bevy](https://user-images.githubusercontent.com/13908946/206572736-8cc8749f-387f-44fa-8317-e5c929729a2e.png)

The three dots of the loading indicator are animated.

## How it works

1. The game script is imported asynchronously via `import("./bevy_game.wasm").then(...)`.
2. A `div` for the loading screen was added inside the `body`.
3. A `loading-screen.mjs` script implements the loading screen:
  1. Once the document has been loaded, the three dots are animated.
  2. A mutation observer waits for the `canvas` element to be created. This indicates that the game has finished loading.
  3. Once this happens, the loading screen and mutation observer is removed.

## How to test it

I created the `wasm` folder which contains everything needed to run the game on the web.
Personally I use `cargo bavy run --wasm` (via [`cargo-bavy`](https://github.com/TimJentzsch/cargo-bavy)) to run the changes locally.

Alternatively, you can do the following:
- Copy the `assets` folder into the `wasm` folder.
- Compile to the `wasm32-unknown-unknown` target in release mode.
- Create bindings for the wasm file and move them to the `wasm` folder. They should be named `bevy_game.js` and `bevy_game.wasm` (note that these are different names than before).
- Host the `wasm` folder on a webserver.

In Firefox, you can turn on throttling in the network tab to see the loading screen. In Chrome it should work in a similar way.

## TODO

- [ ] Get feedback for loading screen "design".
- [ ] Adjust README instructions for running the game in the browser.
- [ ] Adjust GitHub workflows to use the new wasm assets.
